### PR TITLE
CM-326: Fixed labels

### DIFF
--- a/src/pages/payroll/PayrollPage.js
+++ b/src/pages/payroll/PayrollPage.js
@@ -103,7 +103,7 @@ function PayrollPage({
   const handleSave = () => {
     createPayroll(
       editedPayroll,
-      formatMessageWithValues('payroll.mutation.create', mutationLabel(payroll)),
+      formatMessageWithValues('payroll.mutation.createLabel', mutationLabel(editedPayroll)),
     );
     back();
   };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -73,5 +73,9 @@
     "payroll.paymentMethod": "Payment Method",
     "payroll.tasks.update.title": "Approve Payroll Tasks",
     "payroll.tasks.reconciliation.title": "Payroll Reconciliation Tasks",
-    "payroll.payroll.includedUnpaid": "Included unpaid"
+    "payroll.payroll.includedUnpaid": "Included unpaid", 
+
+    "payroll.mutation.createLabel": "Create Payroll '{name}'",
+
+    "payroll.mutation.deleteLabel": "Delete Payroll '{name}'"
 }

--- a/src/utils/string-utils.js
+++ b/src/utils/string-utils.js
@@ -4,4 +4,5 @@ export const pageTitle = (item) => ({
 
 export const mutationLabel = (item) => ({
   id: item?.id,
+  name: item?.name,
 });


### PR DESCRIPTION
Some of the labels were not included in translations which resulted in display of unintuitive keys. 

There is still issue with handling error output from backend but it's not adressed in scope of this PR. 