### PR TITLE
CM-329: journalize payroll creation and remove going back to searcher

### DIFF
--- a/src/pages/payroll/PayrollPage.js
+++ b/src/pages/payroll/PayrollPage.js
@@ -46,6 +46,7 @@ function PayrollPage({
   deletePayrolls,
   coreConfirm,
   clearConfirm,
+  journalize,
 }) {
   const modulesManager = useModulesManager();
   const classes = useStyles();
@@ -98,14 +99,16 @@ function PayrollPage({
     return true;
   };
 
-  const canSave = () => !mandatoryFieldsEmpty() && !readOnly;
+  const canSave = () => {
+    console.log(!mandatoryFieldsEmpty(), readOnly, !mandatoryFieldsEmpty() && !readOnly);
+    return !mandatoryFieldsEmpty() && !readOnly;
+  };
 
   const handleSave = () => {
     createPayroll(
       editedPayroll,
       formatMessageWithValues('payroll.mutation.create', mutationLabel(payroll)),
     );
-    back();
   };
 
   const deletePayrollCallback = () => deletePayrolls(

--- a/src/pages/payroll/PayrollPage.js
+++ b/src/pages/payroll/PayrollPage.js
@@ -99,10 +99,7 @@ function PayrollPage({
     return true;
   };
 
-  const canSave = () => {
-    console.log(!mandatoryFieldsEmpty(), readOnly, !mandatoryFieldsEmpty() && !readOnly);
-    return !mandatoryFieldsEmpty() && !readOnly;
-  };
+  const canSave = () => !mandatoryFieldsEmpty() && !readOnly;
 
   const handleSave = () => {
     createPayroll(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -23,6 +23,8 @@
     "payroll.payroll.benefitPlan": "Benefit Plan",
     "payroll.payroll.customFilter": "Custom Filter",
     "payroll.payrollSearcher.results": "{totalCount} Payrolls Found",
+    "payroll.payroll.mutation.create": "Create Payroll {id}",
+    "payroll.payroll.mutation.deleteLabel": "Delete Payroll {id}",
     
     "payroll.payroll.paymentPoint": "Payment Point",
     "payroll.paymentPoint.label": "Payment Point",


### PR DESCRIPTION
https://openimis.atlassian.net/browse/CM-329


This PR fixes journalizing payroll creation and also removes going back to searcher once payroll is created. It was not consistent with the rest of the flows in the project and it was causing issue that searcher was fetching data faster than it was uploaded.