### PR TITLE
Align payment point create tooltip key with module convention

### DIFF
--- a/src/pages/payment-point/PaymentPointsPage.js
+++ b/src/pages/payment-point/PaymentPointsPage.js
@@ -48,7 +48,7 @@ function PaymentPointsPage() {
               <AddIcon />
             </Fab>
           </div>,
-          formatMessage('tooltip.createButton'),
+          formatMessage('createButton.tooltip'),
         )}
     </div>
   );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9,7 +9,7 @@
   "payroll.paymentPoint.mutation.deleteLabel": "Delete Payment Point {id}",
   "payroll.paymentPoint.mutation.updateLabel": "Update Payment Point {id}",
   "payroll.tooltip.viewDetails": "View details",
-  "payroll.tooltip.createButton": "Create",
+  "payroll.createButton.tooltip": "Create",
   "payroll.tooltip.isDeleted": "Show Deleted",
   "payroll.PaymentPointSearcher.results": "{totalCount} Payment Points Found",
   "payroll.paymentPoint.delete.confirm.title": "Delete Payment Point {name}",


### PR DESCRIPTION
# Description

`PaymentPointsPage` used `formatMessage('tooltip.createButton')` while the rest of this module — and every other openIMIS module — uses `formatMessage('createButton.tooltip')`.  The mismatched key diverged from the established convention used across the platform and made the tooltip harder to locate when searching module translations.

This PR renames the translation key to `payroll.createButton.tooltip` and updates the consumer to match.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [x] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)

Blocked by / related to: openimis/openimis-dist_dkr#99 (this key is exercised by the payment-point E2E tests added in that PR).

---

## Changes

- [x] Rename `payroll.tooltip.createButton` → `payroll.createButton.tooltip` in `src/translations/en.json`
- [x] Update `PaymentPointsPage.js` to use `formatMessage('createButton.tooltip')`

---

## Behaviour Before / After

| Scenario | Before | After |
|---|---|---|
| Hover the Create FAB on the Payment Points page | Tooltip resolves via `tooltip.createButton` (diverged key) | Tooltip resolves via `createButton.tooltip` (module convention) |
| Visible text | "Create" | "Create" (unchanged) |

No user-visible behaviour changes — this is a key-naming cleanup that aligns with the rest of the module and platform.

---

## Demo

_No visible change — the rendered tooltip text is identical._

## Checklist

- [x] Naming matches the `createButton.tooltip` convention used in other openIMIS modules
- [x] No stale references to the old key remain (`grep tooltip.createButton` is clean in this repo)
- [x] No translation strings lost — only the key is renamed